### PR TITLE
Take all non-virtual schema fields for insert

### DIFF
--- a/lib/vax/adapter/helpers.ex
+++ b/lib/vax/adapter/helpers.ex
@@ -46,10 +46,11 @@ defmodule Vax.Adapter.Helpers do
           :antidotec_map.antidote_map()
   def build_insert_map(_repo, schema) do
     schema_types = schema_types(schema)
+    schema_fields = Enum.reject(schema.__schema__(:fields), &schema.__schema__(:virtual_type, &1))
 
     schema
     |> Map.from_struct()
-    |> Map.drop([:__meta__, :__struct__])
+    |> Map.take(schema_fields)
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
     |> Enum.reduce(:antidotec_map.new(), fn {field, value}, map ->
       update_map_value(map, schema_types, field, value, schema.__struct__)


### PR DESCRIPTION
Ash Framework adds additional schema fields and virtual fields, so when working on an Ash/Vaxine data layer, the insert fails here.